### PR TITLE
Add missing event property to regInfo, switch to cordova/exec/proxy for the require statement

### DIFF
--- a/src/windows8/NotificationHubProxy.js
+++ b/src/windows8/NotificationHubProxy.js
@@ -58,6 +58,7 @@ module.exports = {
                 regInfo.registrationId = result;
                 regInfo.channelUri = notificationChannel.uri;
                 regInfo.notificationHubPath = notificationHubPath;
+                regInfo.event = 'registerApplication';
 
                 success(regInfo);
             }, fail);
@@ -83,4 +84,4 @@ module.exports = {
 
 }
 
-require("cordova/windows8/commandProxy").add("NotificationHub", module.exports);
+require("cordova/exec/proxy").add("NotificationHub", module.exports);


### PR DESCRIPTION
This fixes 2 bugs on Windows 10:
1. hub.registerApplicationAsync doesn't get a result (because the event property isn't set)
2. require('cordova/windows8/commandProxy') doesn't work and needs to be replaced with cordova/exec/proxy
